### PR TITLE
Handle horizontal ellipsis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,3 +15,5 @@ jobs:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           channel_id: ${{ secrets.SLACK_CHANNEL }}
           project_name: Slack notification action
+          repo_owner_name: ajainvivek
+          repo_name: slack-notify-release

--- a/index.js
+++ b/index.js
@@ -2,12 +2,17 @@ const core = require('@actions/core')
 const github = require('@actions/github')
 const https = require('https')
 
-const truncateString = (string, limit) => {
+const processString = (string, limit) => {
+  // truncate string if it's longer than the limit
   if (string.length > limit) {
-    return string.substring(0, limit) + '...'
+    string = string.substring(0, limit) + "...";
   }
-  return string
-}
+
+  // Slack API does not support horizontal ellipsis (…), so we need to remove them
+  string = string.replace(/…/g, "...");
+
+  return string;
+};
 
 const main = async () => {
   const slackToken = core.getInput('slack_token')
@@ -31,7 +36,7 @@ const main = async () => {
 
   const latestReleaseTag = latestRelease.tag_name
   const releaseName = latestRelease.name
-  const releaseBody = truncateString(latestRelease.body, 500)
+  const releaseBody = processString(latestRelease.body, 500)
   const releaseAuthor = latestRelease.author
 
   // Get the changelog URL


### PR DESCRIPTION
Slack API does not support horizontal ellipsis(…). Payload with this character will cause json validation issue.